### PR TITLE
fixed manual, memory, stack; moved platform information

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,13 @@
 VERSIONLOG
 
+0.5.2 2018-05-14
+  bugfixes: -H switch now does find the manual 
+            -m does overwrite settings from rc
+  added `ulimit -s unlimited` to avoid problems at runtime
+  system information will be gathered where it is actually running,
+  not where it was called from
+  internal: exchanged /bsub_rwth_project/ with /bsub_project/ 
+
 0.5.1 2018-04-13
   minor bugfixes
   initial tests with Multiwfn 3.5
@@ -58,4 +66,4 @@ VERSIONLOG
   The first working draft of the script.
   Version 3.3.8 of Multiwfn.
 
-(Martin; 0.5.1; 2018-04-13)
+(Martin; 0.5.2; 2018-05-14)

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -7,9 +7,9 @@ working on it further, but until then see the following.
 
 (.) The script
 
-  You probably have obtained the script already, read the readme
-  and are ready to modify it to your system. Below are some
-  recommendations about how I have installed it.
+  You probably have obtained the script already, have read the 
+  readme file and are ready to modify it to your system. 
+  Below are some recommendations about how I have installed it.
 
 (a) Variables
 
@@ -24,7 +24,7 @@ working on it further, but until then see the following.
 
   I am currently unsure (version 0.5.0 of this script)
   what happens if such variables are set, 
-  I need to test this again.
+  I need to test this again. (But I have no time.)
 
   If variables are unset, they will be replaced by default 
   values or they can be specified via the option switches,
@@ -53,6 +53,10 @@ working on it further, but until then see the following.
   (Again, I am not sure anymore what actually happens,
   but it is safe to delete those lines.)
 
+  If the script finds executable commands 'Multiwfn', or
+  'multiwfn', it will abort, make sure nothing is sourced 
+  at that time.
+
 (b) Unpacking
 
   I personally like to have a seperate user for any
@@ -75,9 +79,10 @@ working on it further, but until then see the following.
   which you should modify to suit your needs and copy 
   to the same directory as `runMultiwfn.sh` 
 
-  The only lin you should leav untouched is the one like
+  The only line you should leave untouched is the one like
     nthreads= <digit(s)> //How many threads [...]
   because that will be modified by the script.
+  (It wouldn't have an effect if you'd modify it.)
 
   You should then modify the `runMultiwfn.rc` file, or
   create `.runMultiwfnrc` (takes precedence if found),
@@ -89,7 +94,7 @@ working on it further, but until then see the following.
     (1) the installation directory
     (2) the user's home directory
     (3) the parent work directory
-  and it will use the values from the las one found.
+  and it will use the values from the last one found.
   All settings (except the binaries) can be changed with switches.
 
 (c) Non-GUI versions
@@ -128,5 +133,7 @@ working on it further, but until then see the following.
   The script finds its directory even through multiple links.
   Alternatively you can add an alias, or add the multiwfn
   directory to your PATH.
+  Do not use the commands 'Multiwfn' or 'multiwfn', as the script will
+  abort whenever it finds out that these commands exist, even if it is itself.
 
-(Martin; 0.5.1; 2018-04-13)
+(Martin; 0.5.2; 2018-05-14)

--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ or via github (polyluxus), or any other way you can think of.
 I have a blog (that has not been updated in a while): 
 https://thedailystamp.wordpress.com/
 
-(Martin; 0.5.1; 2018-04-13)
+(Martin; 0.5.2; 2018-05-14)

--- a/configure/runMultiwfn.rc-mcs.rwth
+++ b/configure/runMultiwfn.rc-mcs.rwth
@@ -18,29 +18,27 @@ requested_KMP_STACKSIZE=64000000
 # <digit(s)> is equal to the number of processes to be used
 requested_numCPU=4
 
-# Use the graphical interface (yes/no)
+# Use the graphical interface (yes/no)´
 # This needs a different binary
 request_gui_version="yes"
 
 # The following two lines give the location of the installation 
-installpath_Multiwfn_gui="$HOME/local/multiwfn/multiwfn.current"
-installpath_Multiwfn_nogui="" # Disabled if empty
+installpath_Multiwfn_gui="$HOME/local/multiwfn/Multiwfn_3.5_bin_Linux"
+installpath_Multiwfn_nogui="$HOME/local/multiwfn/Multiwfn_3.5_bin_Linux_noGUI" # Disabled if empty
 
 # Request default execution mode (i.e. could be set to remote)
-# (Setting this here is not tested yet; be careful.)
 execmode="default"
 
 # Select a queueing system (pbs-gen/bsub-rwth)
-request_qsys="pbs-gen"
+request_qsys="bsub-rwth"
 
 # Account to project (only for rwth)
-bsub_project="default"
+bsub_project="mangan2"
 
 # By default clean up the temporary setting.ini
-settingsini_nocleanup="false"
+settingsini_nocleanup="true"
 
 # Set a default pdfviewer (needs to be an executable command found through PATH)
 # Tested in that order are: "$use_pdfviewer" xdg-open gvfs-open evince okular less 
-use_pdfviewer="xpdf"
+use_pdfviewer="evince"
 
-# (Martin; 0.5.2; 2018-05-14)


### PR DESCRIPTION
- fixed https://github.com/polyluxus/runMultiwfn.bash/issues/6 https://github.com/polyluxus/runMultiwfn.bash/issues/7 https://github.com/polyluxus/runMultiwfn.bash/issues/8 

- configure directory with (soon more) commented rc files

```
VERSIONLOG

0.5.2 2018-05-14
  bugfixes: -H switch now does find the manual
            -m does overwrite settings from rc
  added `ulimit -s unlimited` to avoid problems at runtime
  system information will be gathered where it is actually running,
  not where it was called from
  internal: exchanged /bsub_rwth_project/ with /bsub_project/
```
